### PR TITLE
Implement new buildGo.external that traverses external packages automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,20 @@ in buildGo.program {
   | `deps`    | `list<drv>`  | List of dependencies (i.e. other Go libraries) | no        |
   | `path`    | `string`     | Go import path for the resulting library       | no        |
 
-* `buildGo.external`: Build a Go library or program using standard `go` tooling.
+* `buildGo.external`: Build an externally defined Go library or program.
 
-  This exists for compatibility with complex external dependencies. In theory it
-  is possible to write `buildGo.package` specifications for each subpackage of
-  an external dependency, but it is often cumbersome to do so.
+  This function performs analysis on the supplied source code (which
+  can use the standard Go tooling layout) and creates a tree of all
+  the packages contained within.
 
-  | parameter | type           | use                                            | required? |
-  |-----------|----------------|------------------------------------------------|-----------|
-  | `path`    | `string`       | Go import path for the resulting library       | yes       |
-  | `src`     | `path`         | Path to the source **directory**               | yes       |
-  | `deps`    | `list<drv>`    | List of dependencies (i.e. other Go libraries) | no        |
-  | `srcOnly` | `bool`         | Only copy sources, do not perform a build.     | no        |
-  | `targets` | `list<string>` | Sub-packages to build (defaults to all)        | no        |
+  This exists for compatibility with external libraries that were not
+  defined using buildGo.
+
+  | parameter | type           | use                                           | required? |
+  |-----------|----------------|-----------------------------------------------|-----------|
+  | `path`    | `string`       | Go import path for the resulting package      | yes       |
+  | `src`     | `path`         | Path to the source **directory**              | yes       |
+  | `deps`    | `list<drv>`    | List of dependencies (i.e. other Go packages) | no        |
 
   For some examples of how `buildGo.external` is used, check out
   [`proto.nix`](./proto.nix).

--- a/buildGo.nix
+++ b/buildGo.nix
@@ -98,7 +98,7 @@ let
   };
 
   # Build a Go library out of the specified gRPC definition.
-  grpc = args: proto (args // { extraDeps = [ protoLibs.goGrpc ]; });
+  grpc = args: proto (args // { extraDeps = [ protoLibs.goGrpc.gopkg ]; });
 
 in {
   # Only the high-level builder functions are exposed, but made

--- a/buildGo.nix
+++ b/buildGo.nix
@@ -70,7 +70,7 @@ let
     mkdir -p $out/${path}
     ${srcList path (map (s: "${s}") srcs)}
     ${go}/bin/go tool compile -o $out/${path}.a -trimpath=$PWD -trimpath=${go} -p ${path} ${includeSources uniqueDeps} ${spaceOut srcs}
-  '') // { goDeps = uniqueDeps; };
+  '') // { goDeps = uniqueDeps; goImportPath = path; };
 
   # Build a Go library out of the specified protobuf definition.
   proto = { name, proto, path ? name, extraDeps ? [] }: (makeOverridable package) {

--- a/buildGo.nix
+++ b/buildGo.nix
@@ -76,8 +76,8 @@ let
   # directory that follows the standard Go layout and was not built
   # with buildGo.nix.
   #
-  # The derivation for each actual dependency will reside in an
-  # attribute named "gopkg".
+  # The derivation for each actual package will reside in an attribute
+  # named "gopkg", and an attribute named "gobin" for binaries.
   external = import ./external { inherit pkgs program package; };
 
   # Import support libraries needed for protobuf & gRPC support
@@ -88,10 +88,10 @@ let
   # Build a Go library out of the specified protobuf definition.
   proto = { name, proto, path ? name, extraDeps ? [] }: (makeOverridable package) {
     inherit name path;
-    deps = [ protoLibs'.protobuf ] ++ extraDeps;
+    deps = [ protoLibs.goProto.proto.gopkg ] ++ extraDeps;
     srcs = lib.singleton (runCommand "goproto-${name}.pb.go" {} ''
       cp ${proto} ${baseNameOf proto}
-      ${protobuf}/bin/protoc --plugin=${protoLibs.goProto}/bin/protoc-gen-go \
+      ${protobuf}/bin/protoc --plugin=${protoLibs.goProto.protoc-gen-go.gopkg}/bin/protoc-gen-go \
         --go_out=plugins=grpc,import_path=${baseNameOf path}:. ${baseNameOf proto}
       mv *.pb.go $out
     '');

--- a/buildGo.nix
+++ b/buildGo.nix
@@ -73,7 +73,7 @@ let
   '') // { goDeps = uniqueDeps; };
 
   # Build a Go library out of the specified protobuf definition.
-  proto = { name, proto, path ? name, extraDeps ? [] }: package {
+  proto = { name, proto, path ? name, extraDeps ? [] }: (makeOverridable package) {
     inherit name path;
     deps = [ protoLibs.goProto ] ++ extraDeps;
     srcs = lib.singleton (runCommand "goproto-${name}.pb.go" {} ''

--- a/external/default.nix
+++ b/external/default.nix
@@ -3,7 +3,17 @@
 { pkgs, program, package }:
 
 let
-  inherit (builtins) elemAt foldl' fromJSON head length readFile replaceStrings tail throw;
+  inherit (builtins)
+    elemAt
+    foldl'
+    fromJSON
+    head
+    length
+    readFile
+    replaceStrings
+    tail
+    throw;
+
   inherit (pkgs) lib runCommand go jq ripgrep;
 
   pathToName = p: replaceStrings ["/"] ["_"] (toString p);

--- a/external/default.nix
+++ b/external/default.nix
@@ -1,0 +1,29 @@
+# Copyright 2019 Google LLC.
+# SPDX-License-Identifier: Apache-2.0
+{ runCommand, go, jq, ripgrep, program }:
+
+let
+  # Collect all non-vendored dependencies from the Go standard library
+  # into a file that can be used to filter them out when processing
+  # dependencies.
+  stdlibPackages = runCommand "stdlib-pkgs.json" {} ''
+    export GOPATH=/dev/null
+    ${go}/bin/go list all | \
+      ${ripgrep}/bin/rg -v 'vendor' | \
+      ${jq}/bin/jq -R '.' | \
+      ${jq}/bin/jq -c -s 'map({key: ., value: true}) | from_entries' \
+      > $out
+  '';
+
+  analyser = program {
+    name = "analyser";
+
+    srcs = [
+      ./main.go
+    ];
+
+    x_defs = {
+      "main.stdlibList" = "${stdlibPackages}";
+    };
+  };
+in analyser

--- a/external/default.nix
+++ b/external/default.nix
@@ -1,8 +1,13 @@
 # Copyright 2019 Google LLC.
 # SPDX-License-Identifier: Apache-2.0
-{ runCommand, go, jq, ripgrep, program }:
+{ pkgs, program, package }:
 
 let
+  inherit (builtins) foldl'fromJSON head readFile replaceStrings tail throw;
+  inherit (pkgs) lib runCommand go jq ripgrep;
+
+  pathToName = p: replaceStrings ["/"] ["_"] (toString p);
+
   # Collect all non-vendored dependencies from the Go standard library
   # into a file that can be used to filter them out when processing
   # dependencies.
@@ -26,4 +31,26 @@ let
       "main.stdlibList" = "${stdlibPackages}";
     };
   };
-in analyser
+
+  mkset = path: value:
+    if path == [] then { gopkg = value; }
+    else { "${head path}" = mkset (tail path) value; };
+
+  toPackage = self: src: path: entry: package {
+    name = pathToName entry.name entry.name;
+    path = lib.concatStringsSep "/" ([ path ] ++ entry.locator);
+    srcs = map (f: src + ("/" + f)) entry.files;
+    deps = map (d: lib.attrByPath (d ++ [ "gopkg" ]) (
+      throw "missing local dependency '${lib.concatStringsSep "." d}' in '${path}'"
+    ) self) entry.localDeps;
+  };
+
+in { src, path, deps ? [] }: let
+  name = pathToName path;
+  analysisOutput = runCommand "${name}-structure.json" {} ''
+    ${analyser}/bin/analyser -path ${path} -source ${src} > $out
+  '';
+  analysis = fromJSON (readFile analysisOutput);
+in lib.fix(self: foldl' lib.recursiveUpdate {} (
+  map (entry: mkset entry.locator (toPackage self src path entry)) analysis
+))

--- a/external/main.go
+++ b/external/main.go
@@ -1,0 +1,159 @@
+// Copyright 2019 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+// This tool analyses external (i.e. not built with `buildGo.nix`) Go
+// packages to determine a build plan that Nix can import.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Path to a JSON file describing all standard library import paths.
+// This file is generated and set here by Nix during the build
+// process.
+var stdlibList string
+
+// pkg describes a single Go package within the specified source
+// directory.
+//
+// Return information includes the local (relative from project root)
+// and external (none-stdlib) dependencies of this package.
+type pkg struct {
+	Name        string   `json:"name"`
+	Source      string   `json:"source"`
+	Files       []string `json:"files"`
+	LocalDeps   []string `json:"localDeps"`
+	ForeignDeps []string `json:"foreignDeps"`
+}
+
+// findGoDirs returns a filepath.WalkFunc that identifies all
+// directories that contain Go source code in a certain tree.
+func findGoDirs(at string) ([]string, error) {
+	var goDirs []string
+	dir := ""
+
+	err := filepath.Walk(at, func(path string, info os.FileInfo, err error) error {
+		// Skip testdata
+		if info.IsDir() && info.Name() == "testdata" {
+			return filepath.SkipDir
+		}
+
+		// Keep track of the last seen directory.
+		if info.IsDir() {
+			dir = path
+			return nil
+		}
+
+		// If the directory has already been "popped", nothing else needs
+		// to happen.
+		if dir == "" {
+			return nil
+		}
+
+		// If the current file is a Go file, then the directory is popped
+		// (i.e. marked as a Go directory).
+		if strings.HasSuffix(info.Name(), ".go") && !strings.HasSuffix(info.Name(), "_test.go") {
+			goDirs = append(goDirs, dir)
+			dir = ""
+			return nil
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return goDirs, nil
+}
+
+// analysePackage loads and analyses the imports of a single Go
+// package, returning the data that is required by the Nix code to
+// generate a derivation for this package.
+func analysePackage(root, source, path string, stdlib map[string]bool) (pkg, error) {
+	ctx := build.Default
+
+	p, err := ctx.ImportDir(source, build.IgnoreVendor)
+	if err != nil {
+		return pkg{}, err
+	}
+
+	local := []string{}
+	foreign := []string{}
+
+	for _, i := range p.Imports {
+		if stdlib[i] {
+			continue
+		}
+
+		if strings.HasPrefix(i, path) {
+			local = append(local, i)
+		} else {
+			foreign = append(foreign, i)
+		}
+	}
+
+	analysed := pkg{
+		Name:        strings.TrimPrefix(source, root+"/"),
+		Source:      source,
+		Files:       p.GoFiles,
+		LocalDeps:   local,
+		ForeignDeps: foreign,
+	}
+
+	return analysed, nil
+}
+
+func loadStdlibPkgs(from string) (pkgs map[string]bool, err error) {
+	f, err := ioutil.ReadFile(from)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(f, &pkgs)
+	return
+}
+
+func main() {
+	// TODO(tazjin): Remove default values
+	source := flag.String("source", "/nix/store/fzp67ris29zg5zfs65z0q245x0fahgll-source", "path to directory with sources to process")
+	path := flag.String("path", "github.com/golang/protobuf", "import path for the package")
+
+	flag.Parse()
+
+	if *source == "" {
+		log.Fatalf("-source flag must be specified")
+	}
+
+	stdlibPkgs, err := loadStdlibPkgs(stdlibList)
+	if err != nil {
+		log.Fatalf("failed to load standard library index from %q: %s\n", stdlibList, err)
+	}
+
+	goDirs, err := findGoDirs(*source)
+	if err != nil {
+		log.Fatalf("failed to walk source directory '%s': %s\n", source, err)
+	}
+
+	all := []pkg{}
+	for _, d := range goDirs {
+		analysed, err := analysePackage(*source, d, *path, stdlibPkgs)
+		if err != nil {
+			log.Fatalf("failed to analyse package at %q: %s", d, err)
+		}
+		all = append(all, analysed)
+	}
+
+	j, _ := json.MarshalIndent(all, "", "  ") // TODO: no indent
+	fmt.Println(string(j))
+}

--- a/external/main.go
+++ b/external/main.go
@@ -34,6 +34,7 @@ type pkg struct {
 	Files       []string   `json:"files"`
 	LocalDeps   [][]string `json:"localDeps"`
 	ForeignDeps []string   `json:"foreignDeps"`
+	IsCommand   bool       `json:"isCommand"`
 }
 
 // findGoDirs returns a filepath.WalkFunc that identifies all
@@ -116,6 +117,7 @@ func analysePackage(root, source, importpath string, stdlib map[string]bool) (pk
 		Files:       files,
 		LocalDeps:   local,
 		ForeignDeps: foreign,
+		IsCommand:   p.IsCommand(),
 	}, nil
 }
 

--- a/external/main.go
+++ b/external/main.go
@@ -94,19 +94,27 @@ func analysePackage(root, source, importpath string, stdlib map[string]bool) (pk
 	}
 
 	prefix := strings.TrimPrefix(source, root+"/")
+
+	name := []string{}
+	if len(prefix) != len(source) {
+		name = strings.Split(prefix, "/")
+	} else {
+		// Otherwise, the name is empty since its the root package and no
+		// prefix should be added to files.
+		prefix = ""
+	}
+
 	files := []string{}
 	for _, f := range p.GoFiles {
 		files = append(files, path.Join(prefix, f))
 	}
 
-	analysed := pkg{
-		Name:        strings.Split(prefix, "/"),
+	return pkg{
+		Name:        name,
 		Files:       files,
 		LocalDeps:   local,
 		ForeignDeps: foreign,
-	}
-
-	return analysed, nil
+	}, nil
 }
 
 func loadStdlibPkgs(from string) (pkgs map[string]bool, err error) {

--- a/external/main.go
+++ b/external/main.go
@@ -29,7 +29,8 @@ var stdlibList string
 // Return information includes the local (relative from project root)
 // and external (none-stdlib) dependencies of this package.
 type pkg struct {
-	Name        []string   `json:"name"`
+	Name        string     `json:"name"`
+	Locator     []string   `json:"locator"`
 	Files       []string   `json:"files"`
 	LocalDeps   [][]string `json:"localDeps"`
 	ForeignDeps []string   `json:"foreignDeps"`
@@ -95,12 +96,12 @@ func analysePackage(root, source, importpath string, stdlib map[string]bool) (pk
 
 	prefix := strings.TrimPrefix(source, root+"/")
 
-	name := []string{}
+	locator := []string{}
 	if len(prefix) != len(source) {
-		name = strings.Split(prefix, "/")
+		locator = strings.Split(prefix, "/")
 	} else {
-		// Otherwise, the name is empty since its the root package and no
-		// prefix should be added to files.
+		// Otherwise, the locator is empty since its the root package and
+		// no prefix should be added to files.
 		prefix = ""
 	}
 
@@ -110,7 +111,8 @@ func analysePackage(root, source, importpath string, stdlib map[string]bool) (pk
 	}
 
 	return pkg{
-		Name:        name,
+		Name:        path.Join(importpath, prefix),
+		Locator:     locator,
 		Files:       files,
 		LocalDeps:   local,
 		ForeignDeps: foreign,

--- a/proto.nix
+++ b/proto.nix
@@ -19,11 +19,17 @@ in rec {
 
   xnet = external {
     path = "golang.org/x/net";
-    deps = [ xtext ];
+
     src = fetchGit {
       url = "https://go.googlesource.com/net";
       rev = "ffdde105785063a81acd95bdf89ea53f6e0aac2d";
     };
+
+    deps = map (p: p.gopkg) [
+      xtext.secure.bidirule
+      xtext.unicode.bidi
+      xtext.unicode.norm
+    ];
   };
 
   xsys = external {
@@ -48,21 +54,31 @@ in rec {
       url = "https://github.com/google/go-genproto";
       rev = "83cc0476cb11ea0da33dacd4c6354ab192de6fe6";
     };
+
+    deps = with goProto; map (p: p.gopkg) [
+      proto
+      ptypes.any
+    ];
   };
 
   goGrpc = external {
     path = "google.golang.org/grpc";
-    deps = [ goProto xnet xsys genproto ];
+    deps = map (p: p.gopkg) ([
+      xnet.trace
+      xnet.http2
+      xsys.unix
+      xnet.http2.hpack
+      genproto.googleapis.rpc.status
+    ] ++ (with goProto; [
+      proto
+      ptypes
+      ptypes.duration
+      ptypes.timestamp
+    ]));
 
     src = fetchGit {
       url = "https://github.com/grpc/grpc-go";
       rev = "d8e3da36ac481ef00e510ca119f6b68177713689";
     };
-
-    targets = [
-      "."
-      "codes"
-      "status"
-    ];
   };
 }

--- a/proto.nix
+++ b/proto.nix
@@ -19,7 +19,6 @@ in rec {
 
   xnet = external {
     path = "golang.org/x/net";
-    srcOnly = true;
     deps = [ xtext ];
     src = fetchGit {
       url = "https://go.googlesource.com/net";
@@ -29,7 +28,6 @@ in rec {
 
   xsys = external {
     path = "golang.org/x/sys";
-    srcOnly = true;
     src = fetchGit {
       url = "https://go.googlesource.com/sys";
       rev = "bd437916bb0eb726b873ee8e9b2dcf212d32e2fd";
@@ -38,7 +36,6 @@ in rec {
 
   xtext = external {
     path = "golang.org/x/text";
-    srcOnly = true;
     src = fetchGit {
       url = "https://go.googlesource.com/text";
       rev = "cbf43d21aaebfdfeb81d91a5f444d13a3046e686";
@@ -47,7 +44,6 @@ in rec {
 
   genproto = external {
     path = "google.golang.org/genproto";
-    srcOnly = true;
     src = fetchGit {
       url = "https://github.com/google/go-genproto";
       rev = "83cc0476cb11ea0da33dacd4c6354ab192de6fe6";


### PR DESCRIPTION
This implements a small Go tool and corresponding logic in Nix that can analyse an externally specified Go project and create a tree of all of its packages, with correct internal dependencies.

Please check out the updated `proto.nix` for usage examples. They are quite close to how things used to work before, but instead of specifying something like `xnet` as a dependency it is now possible to specifically refer to something like `xnet.http2.hpack`.

This makes it *much* easier to interface with complex external libraries, currently at the cost of more granular dependency setups - however some of that can (if desired) be automated away.